### PR TITLE
Remove namphysics include flags, add new arguments required for CCPP_interstitial%create routine

### DIFF
--- a/driver/fvGFS/atmosphere.F90
+++ b/driver/fvGFS/atmosphere.F90
@@ -444,6 +444,7 @@ contains
                                  Atm(mytile)%npz, Atm(mytile)%ng,                                              &
                                  dt_atmos, p_split, Atm(mytile)%flagstruct%k_split,                            &
                                  zvir, Atm(mytile)%flagstruct%p_ref, Atm(mytile)%ak, Atm(mytile)%bk,           &
+                                 liq_wat>0, ice_wat>0, rainwat>0, snowwat>0, graupel>0,                        &
                                  cld_amt>0, kappa, Atm(mytile)%flagstruct%hydrostatic,                         &
                                  Atm(mytile)%flagstruct%do_sat_adj,                                            &
                                  Atm(mytile)%delp, Atm(mytile)%delz, Atm(mytile)%gridstruct%area_64,           &

--- a/makefile
+++ b/makefile
@@ -23,7 +23,7 @@ endif
 
 LIBRARY  = libfv3core.a
 
-FFLAGS   += -I$(FMS_DIR) -I../gfsphysics -I../ipd -I../io -I../namphysics
+FFLAGS   += -I$(FMS_DIR) -I../gfsphysics -I../ipd -I../io
 
 SRCS_f   =
 


### PR DESCRIPTION
This PR:
- remove namphysics include flags
- add new arguments required for `CCPP_interstitial%create` routine

Associated PRs:
https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere/pull/20
https://github.com/NCAR/ccpp-framework/pull/292
https://github.com/NCAR/ccpp-physics/pull/451
https://github.com/NOAA-EMC/fv3atm/pull/115
https://github.com/NOAA-EMC/NEMS/pull/62
https://github.com/ufs-community/ufs-weather-model/pull/126

For regression testing information, see https://github.com/ufs-community/ufs-weather-model/pull/126.