### PR TITLE
Butterfly effect (from @DusanJovic-NOAA)

### DIFF
--- a/model/fv_arrays.F90
+++ b/model/fv_arrays.F90
@@ -974,6 +974,10 @@ module fv_arrays_mod
                              !< Useful for perturbing initial conditions. -1 by default;
                              !< disabled if 0 or negative.
 
+   logical :: butterfly_effect = .false.   !< Flip the least-significant-bit of the lowest level temperature
+                                           !< at the center of domain, if set to .true.
+                                           !< The default value is .false.
+
    integer :: a2b_ord = 4   !< Order of interpolation used by the pressure gradient force
                             !< to interpolate cell-centered (A-grid) values to the grid corners. 
                             !< The default value is 4 (recommended), which uses fourth-order 

--- a/model/fv_arrays.F90
+++ b/model/fv_arrays.F90
@@ -975,7 +975,7 @@ module fv_arrays_mod
                              !< disabled if 0 or negative.
 
    logical :: butterfly_effect = .false.   !< Flip the least-significant-bit of the lowest level temperature
-                                           !< at the center of domain, if set to .true.
+                                           !< at the center of the domain (the center of tile 1), if set to .true.
                                            !< The default value is .false.
 
    integer :: a2b_ord = 4   !< Order of interpolation used by the pressure gradient force

--- a/model/fv_control.F90
+++ b/model/fv_control.F90
@@ -316,6 +316,7 @@ module fv_control_mod
    logical , pointer :: make_hybrid_z  
    logical , pointer :: nudge_qv
    real,     pointer :: add_noise
+   logical , pointer :: butterfly_effect
 
    integer , pointer :: a2b_ord 
    integer , pointer :: c2l_ord 
@@ -669,7 +670,7 @@ module fv_control_mod
                          pnats, dnats, a2b_ord, remap_t, p_ref, d2_bg_k1, d2_bg_k2,  &
                          c2l_ord, dx_const, dy_const, umax, deglat,      &
                          deglon_start, deglon_stop, deglat_start, deglat_stop, &
-                         phys_hydrostatic, use_hydro_pressure, make_hybrid_z, old_divg_damp, add_noise, &
+                         phys_hydrostatic, use_hydro_pressure, make_hybrid_z, old_divg_damp, add_noise, butterfly_effect, &
                          nested, twowaynest, parent_grid_num, parent_tile, nudge_qv, &
                          refinement, nestbctype, nestupdate, nsponge, s_weight, &
                          ioffset, joffset, check_negative, nudge_ic, halo_update_type, gfs_phil, agrid_vel_rst,     &
@@ -1328,6 +1329,7 @@ module fv_control_mod
      make_hybrid_z                 => Atm%flagstruct%make_hybrid_z
      nudge_qv                      => Atm%flagstruct%nudge_qv
      add_noise                     => Atm%flagstruct%add_noise
+     butterfly_effect              => Atm%flagstruct%butterfly_effect
      a2b_ord                       => Atm%flagstruct%a2b_ord
      c2l_ord                       => Atm%flagstruct%c2l_ord
      ndims                         => Atm%flagstruct%ndims

--- a/tools/external_ic.F90
+++ b/tools/external_ic.F90
@@ -499,14 +499,12 @@ contains
       integer :: levp = 64
       logical :: checker_tr = .false.
       integer :: nt_checker = 0
-      logical :: butterfly_effect = .false.
-      integer :: i_butterfly, j_butterfly
       real(kind=R_GRID), dimension(2):: p1, p2, p3
       real(kind=R_GRID), dimension(3):: e1, e2, ex, ey
       integer:: i,j,k,nts, ks
       integer:: liq_wat, ice_wat, rainwat, snowwat, graupel, ntclamt
       namelist /external_ic_nml/ filtered_terrain, levp, gfs_dwinds, &
-                                 checker_tr, nt_checker, butterfly_effect
+                                 checker_tr, nt_checker
 #ifdef GFSL64
    real, dimension(65):: ak_sj, bk_sj
    data ak_sj/20.00000,      68.00000,     137.79000,   &
@@ -860,21 +858,6 @@ contains
           call start_regional_cold_start(Atm(1), dt_atmos, ak, bk, levp, &
                                          is, ie, js, je, &
                                          isd, ied, jsd, jed )
-        endif
-
-!
-!***  Butterfly effect
-!
-        if (butterfly_effect) then
-          if (n==1 .and. Atm(n)%tile == 1) then
-            i_butterfly = Atm(1)%npx / 2
-            j_butterfly = Atm(1)%npy / 2
-            if (is <= i_butterfly .and. i_butterfly <= ie) then
-            if (js <= j_butterfly .and. j_butterfly <= je) then
-               ps(i_butterfly,j_butterfly) = nearest(ps(i_butterfly,j_butterfly), -1.0)
-            endif
-            endif
-          endif
         endif
 
 !

--- a/tools/external_ic.F90
+++ b/tools/external_ic.F90
@@ -499,12 +499,14 @@ contains
       integer :: levp = 64
       logical :: checker_tr = .false.
       integer :: nt_checker = 0
+      logical :: butterfly_effect = .false.
+      integer :: i_butterfly, j_butterfly
       real(kind=R_GRID), dimension(2):: p1, p2, p3
       real(kind=R_GRID), dimension(3):: e1, e2, ex, ey
       integer:: i,j,k,nts, ks
       integer:: liq_wat, ice_wat, rainwat, snowwat, graupel, ntclamt
       namelist /external_ic_nml/ filtered_terrain, levp, gfs_dwinds, &
-                                 checker_tr, nt_checker
+                                 checker_tr, nt_checker, butterfly_effect
 #ifdef GFSL64
    real, dimension(65):: ak_sj, bk_sj
    data ak_sj/20.00000,      68.00000,     137.79000,   &
@@ -858,6 +860,21 @@ contains
           call start_regional_cold_start(Atm(1), dt_atmos, ak, bk, levp, &
                                          is, ie, js, je, &
                                          isd, ied, jsd, jed )
+        endif
+
+!
+!***  Butterfly effect
+!
+        if (butterfly_effect) then
+          if (n==1 .and. Atm(n)%tile == 1) then
+            i_butterfly = Atm(1)%npx / 2
+            j_butterfly = Atm(1)%npy / 2
+            if (is <= i_butterfly .and. i_butterfly <= ie) then
+            if (js <= j_butterfly .and. j_butterfly <= je) then
+               ps(i_butterfly,j_butterfly) = nearest(ps(i_butterfly,j_butterfly), -1.0)
+            endif
+            endif
+          endif
         endif
 
 !

--- a/tools/fv_restart.F90
+++ b/tools/fv_restart.F90
@@ -222,6 +222,8 @@ contains
     integer :: npts
     real    :: sumpertn
 
+    integer :: i_butterfly, j_butterfly
+
     rgrav = 1. / grav
 
     if(.not.module_is_initialized) call mpp_error(FATAL, 'You must call fv_restart_init.')
@@ -625,6 +627,25 @@ contains
         call mpp_sum(npts)
         write(errstring,'(A, E16.9)') "RMS added noise: ", sqrt(sumpertn/npts)
         call mpp_error(NOTE, errstring)
+     endif
+
+     if (Atm(n)%flagstruct%butterfly_effect) then
+        if (n==1 .and. Atm(n)%tile == 1) then
+           i_butterfly = Atm(n)%npx / 2
+           j_butterfly = Atm(n)%npy / 2
+           if (isc <= i_butterfly .and. i_butterfly <= iec) then
+           if (jsc <= j_butterfly .and. j_butterfly <= jec) then
+
+              write(*,'(A, I0, A, I0)') "Adding butterfly effect at (i,j) ", i_butterfly, ", ", j_butterfly
+              write(*,'(A, E24.17)') "pt (before) :", Atm(n)%pt(i_butterfly,j_butterfly,Atm(n)%npz)
+
+              Atm(n)%pt(i_butterfly,j_butterfly,Atm(n)%npz) = nearest(Atm(n)%pt(i_butterfly,j_butterfly,Atm(n)%npz), -1.0)
+
+              write(*,'(A, E24.17)') "pt (after)  :", Atm(n)%pt(i_butterfly,j_butterfly,Atm(n)%npz)
+
+           endif
+           endif
+        endif
      endif
 
       if (Atm(n)%grid_number > 1) then


### PR DESCRIPTION
This PR adds the option flip the least-significant-bit of the lowest level temperature at the center of domain, if the newly introduced logical `butterfly_effect` is set to `.true.` (from @DusanJovic-NOAA)

This PR is tested and merged together with:

https://github.com/NCAR/ccpp-physics/pull/423
https://github.com/NOAA-EMC/fv3atm/pull/93
https://github.com/ufs-community/ufs-weather-model/pull/94

For regression testing, see https://github.com/ufs-community/ufs-weather-model/pull/94.