### PR TITLE
Fixes for GNU compilation issues (from @XiaqiongZhou-NOAA)

### DIFF
--- a/driver/fvGFS/atmosphere.F90
+++ b/driver/fvGFS/atmosphere.F90
@@ -944,14 +944,14 @@ contains
    !--- if needed, flip the indexing during this step
    if (flip) then
      if (.not. relative) then
-       z(:,:,1) = Atm(mygrid)%phis(:,:)/grav
+       z(isc:iec,jsc:jec,1) = Atm(mygrid)%phis(isc:iec,jsc:jec)/grav
      endif
      do k = 2,npz+1
        z(:,:,k) = z(:,:,k-1) - dz(:,:,npz+2-k)
      enddo
    else
      if (.not. relative) then
-       z(:,:,npz+1) = Atm(mygrid)%phis(:,:)/grav
+       z(isc:iec,jsc:jec,npz+1) = Atm(mygrid)%phis(isc:iec,jsc:jec)/grav
      endif
      do k = npz,1,-1
        z(:,:,k) = z(:,:,k+1) - dz(:,:,k)

--- a/driver/fvGFS/atmosphere.F90
+++ b/driver/fvGFS/atmosphere.F90
@@ -944,14 +944,14 @@ contains
    !--- if needed, flip the indexing during this step
    if (flip) then
      if (.not. relative) then
-       z(isc:iec,jsc:jec,1) = Atm(mygrid)%phis(isc:iec,jsc:jec)/grav
+       z(1:iec-isc+1,1:jec-jsc+1,1) = Atm(mygrid)%phis(isc:iec,jsc:jec)/grav
      endif
      do k = 2,npz+1
        z(:,:,k) = z(:,:,k-1) - dz(:,:,npz+2-k)
      enddo
    else
      if (.not. relative) then
-       z(isc:iec,jsc:jec,npz+1) = Atm(mygrid)%phis(isc:iec,jsc:jec)/grav
+       z(1:iec-isc+1,1:jec-jsc+1,npz+1) = Atm(mygrid)%phis(isc:iec,jsc:jec)/grav
      endif
      do k = npz,1,-1
        z(:,:,k) = z(:,:,k+1) - dz(:,:,k)

--- a/model/boundary.F90
+++ b/model/boundary.F90
@@ -2365,7 +2365,7 @@ contains
       position = CENTER
    end if
 
-   !Note that *_c does not have values on the parent_proc. 
+   !Note that *_c does not have values on the parent_proc.
    !Must use isu, etc. to get bounds of update region on parent.
    call mpp_get_F2C_index(nest_domain, is_c, ie_c, js_c, je_c, is_f, ie_f, js_f, je_f, nest_level=nest_level, position=position)
    if (child_proc) then
@@ -2536,7 +2536,7 @@ contains
       select case (nestupdate) 
       case (1,2,6,7,8) ! 1 = Conserving update on all variables; 2 = conserving update for cell-centered values; 6 = conserving remap-update
 
-!$OMP parallel do default(none) shared(npz,jsu,jeu,isu,ieu,coarse_dat_recv,parent_grid,var_coarse) 
+!$OMP parallel do default(none) shared(npz,jsu,jeu,isu,ieu,coarse_dat_recv,parent_grid,var_coarse)
          do k=1,npz
          do j=jsu,jeu
          do i=isu,ieu
@@ -2559,7 +2559,7 @@ contains
       select case (nestupdate) 
       case (1,6,7,8)
 
-!$OMP parallel do default(none) shared(npz,jsu,jeu,isu,ieu,coarse_dat_recv,parent_grid,var_coarse) 
+!$OMP parallel do default(none) shared(npz,jsu,jeu,isu,ieu,coarse_dat_recv,parent_grid,var_coarse)
          do k=1,npz
          do j=jsu,jeu+1
          do i=isu,ieu
@@ -2579,7 +2579,7 @@ contains
       select case (nestupdate) 
       case (1,6,7,8)   !averaging update; in-line average for face-averaged values instead of areal average
 
-!$OMP parallel do default(none) shared(npz,jsu,jeu,isu,ieu,coarse_dat_recv,parent_grid,var_coarse) 
+!$OMP parallel do default(none) shared(npz,jsu,jeu,isu,ieu,coarse_dat_recv,parent_grid,var_coarse)
          do k=1,npz
          do j=jsu,jeu
          do i=isu,ieu+1

--- a/model/fv_nesting.F90
+++ b/model/fv_nesting.F90
@@ -1870,7 +1870,7 @@ contains
 
  subroutine d2c_setup(u, v, &
       ua, va, &
-	  uc, vc, dord4, &
+      uc, vc, dord4, &
       isd,ied,jsd,jed, is,ie,js,je, npx,npy, &
       grid_type, bounded_domain, &
       se_corner, sw_corner, ne_corner, nw_corner, &

--- a/model/tp_core.F90
+++ b/model/tp_core.F90
@@ -159,7 +159,7 @@ contains
    ord_ou = hord
 
    if (.not. gridstruct%bounded_domain) &
-	call copy_corners(q, npx, npy, 2, gridstruct%bounded_domain, bd, &
+        call copy_corners(q, npx, npy, 2, gridstruct%bounded_domain, bd, &
                           gridstruct%sw_corner, gridstruct%se_corner, gridstruct%nw_corner, gridstruct%ne_corner)
 
    call yppm(fy2, q, cry, ord_in, isd,ied,isd,ied, js,je,jsd,jed, npx,npy, gridstruct%dya, gridstruct%bounded_domain, gridstruct%grid_type, lim_fac)
@@ -178,7 +178,7 @@ contains
    call xppm(fx, q_i, crx(is,js), ord_ou, is,ie,isd,ied, js,je,jsd,jed, npx,npy, gridstruct%dxa, gridstruct%bounded_domain, gridstruct%grid_type, lim_fac)
 
   if (.not. gridstruct%bounded_domain) &
-	call copy_corners(q, npx, npy, 1, gridstruct%bounded_domain, bd, &
+       call copy_corners(q, npx, npy, 1, gridstruct%bounded_domain, bd, &
                                gridstruct%sw_corner, gridstruct%se_corner, gridstruct%nw_corner, gridstruct%ne_corner)
 
   call xppm(fx2, q, crx, ord_in, is,ie,isd,ied, jsd,jed,jsd,jed, npx,npy, gridstruct%dxa, gridstruct%bounded_domain, gridstruct%grid_type, lim_fac)

--- a/tools/external_ic.F90
+++ b/tools/external_ic.F90
@@ -810,7 +810,7 @@ contains
                    Atm%gridstruct%dxc, Atm%gridstruct%dyc, Atm%gridstruct%sin_sg, &
                    Atm%flagstruct%n_zs_filter, cnst_0p20*Atm%gridstruct%da_min, &
                    .false., oro_g, Atm%gridstruct%bounded_domain, &
-	           Atm%domain, Atm%bd)
+                    Atm%domain, Atm%bd)
             if ( is_master() ) write(*,*) 'Warning !!! del-2 terrain filter has been applied ', &
                    Atm%flagstruct%n_zs_filter, ' times'
           else if( Atm%flagstruct%nord_zs_filter == 4 ) then
@@ -818,7 +818,7 @@ contains
                    Atm%gridstruct%dx, Atm%gridstruct%dy,   &
                    Atm%gridstruct%dxc, Atm%gridstruct%dyc, Atm%gridstruct%sin_sg, &
                    Atm%flagstruct%n_zs_filter, .false., oro_g, &
-	           Atm%gridstruct%bounded_domain, &
+                   Atm%gridstruct%bounded_domain, &
                    Atm%domain, Atm%bd)
             if ( is_master() ) write(*,*) 'Warning !!! del-4 terrain filter has been applied ', &
                    Atm%flagstruct%n_zs_filter, ' times'

--- a/tools/fv_diagnostics.F90
+++ b/tools/fv_diagnostics.F90
@@ -2036,7 +2036,7 @@ contains
 
 
 
-       if( idiag%id_slp>0 .or. idiag%id_tm>0 .or. idiag%id_any_hght>0 .or. idiag%id_hght3d .or. idiag%id_c15>0 .or. idiag%id_ctz ) then
+       if( idiag%id_slp>0 .or. idiag%id_tm>0 .or. idiag%id_any_hght>0 .or. idiag%id_hght3d>0 .or. idiag%id_c15>0 .or. idiag%id_ctz>0 ) then
 
           allocate ( wz(isc:iec,jsc:jec,npz+1) )
           call get_height_field(isc, iec, jsc, jec, ngc, npz, Atm(n)%flagstruct%hydrostatic, Atm(n)%delz,  &

--- a/tools/fv_grid_tools.F90
+++ b/tools/fv_grid_tools.F90
@@ -709,8 +709,8 @@ contains
 !----------------------------------------------------------------------------------------------------
                          if ( grid_global(i,j,1,n) < 0. )              &
                               grid_global(i,j,1,n) = grid_global(i,j,1,n) + 2.*pi
-                         if (ABS(grid_global(i,j,1,n)) < 1.d-10) grid_global(i,j,1,n) = 0.0
-                         if (ABS(grid_global(i,j,2,n)) < 1.d-10) grid_global(i,j,2,n) = 0.0
+                         if (ABS(grid_global(i,j,1,1)) < 1.d-10) grid_global(i,j,1,1) = 0.0
+                         if (ABS(grid_global(i,j,2,1)) < 1.d-10) grid_global(i,j,2,1) = 0.0
                          enddo
                       enddo
                    enddo

--- a/tools/fv_grid_tools.F90
+++ b/tools/fv_grid_tools.F90
@@ -709,8 +709,8 @@ contains
 !----------------------------------------------------------------------------------------------------
                          if ( grid_global(i,j,1,n) < 0. )              &
                               grid_global(i,j,1,n) = grid_global(i,j,1,n) + 2.*pi
-                         if (ABS(grid_global(i,j,1,1)) < 1.d-10) grid_global(i,j,1,1) = 0.0
-                         if (ABS(grid_global(i,j,2,1)) < 1.d-10) grid_global(i,j,2,1) = 0.0
+                         if (ABS(grid_global(i,j,1,n)) < 1.d-10) grid_global(i,j,1,n) = 0.0
+                         if (ABS(grid_global(i,j,2,n)) < 1.d-10) grid_global(i,j,2,n) = 0.0
                          enddo
                       enddo
                    enddo

--- a/tools/fv_restart.F90
+++ b/tools/fv_restart.F90
@@ -541,7 +541,7 @@ contains
 
 
     do n = ntileMe,1,-1
-       if (new_nest_topo(n)) then
+       if (new_nest_topo(n) > 0 ) then
           call twoway_topo_update(Atm(n), n==this_grid)
        endif
     end do
@@ -566,7 +566,7 @@ contains
        ntdiag = size(Atm(n)%qdiag,4)
 
 
-       if (.not. ideal_test_case(n)) then
+       if ( ideal_test_case(n) == 0 ) then
 #ifdef SW_DYNAMICS
           Atm(n)%pt(:,:,:)=1.
 #else

--- a/tools/test_cases.F90
+++ b/tools/test_cases.F90
@@ -230,7 +230,7 @@
      integer, parameter :: interpOrder = 1
 
       public :: pz0, zz0
-      public :: test_case, bubble_do, alpha, tracer_test, wind_field, nsolitons, soliton_Umax, soliton_size
+      public :: read_namelist_test_case_nml, alpha
       public :: init_case
 #ifdef NCDF_OUTPUT
       public :: output, output_ncdf
@@ -6360,26 +6360,26 @@ end subroutine terminator_tracers
            call hydro_eq(npz, is, ie, js, je, ps, phis, dry_mass,      &
                          delp, ak, bk, pt, delz, area, ng, .false., hydrostatic, hybrid_z, domain)
 
-	   ! *** Add Initial perturbation ***
-	   if (bubble_do) then
-	       r0 = 100.*sqrt(dx_const**2 + dy_const**2)
-	       icenter = npx/2
-	       jcenter = npy/2
+           ! *** Add Initial perturbation ***
+           if (bubble_do) then
+               r0 = 100.*sqrt(dx_const**2 + dy_const**2)
+               icenter = npx/2
+               jcenter = npy/2
 
-	       do j=js,je
-		  do i=is,ie
-		     dist = (i-icenter)*dx_const*(i-icenter)*dx_const   &
-			   +(j-jcenter)*dy_const*(j-jcenter)*dy_const
-		     dist = min(r0, sqrt(dist))
-		     do k=1,npz
-			prf = ak(k) + ps(i,j)*bk(k)
-			if ( prf > 100.E2 ) then
-			     pt(i,j,k) = pt(i,j,k) + 0.01*(1. - (dist/r0)) * prf/ps(i,j) 
-			endif
-		     enddo
-		  enddo
-	       enddo
-	   endif
+               do j=js,je
+                  do i=is,ie
+                     dist = (i-icenter)*dx_const*(i-icenter)*dx_const   &
+                           +(j-jcenter)*dy_const*(j-jcenter)*dy_const
+                     dist = min(r0, sqrt(dist))
+                     do k=1,npz
+                        prf = ak(k) + ps(i,j)*bk(k)
+                        if ( prf > 100.E2 ) then
+                             pt(i,j,k) = pt(i,j,k) + 0.01*(1. - (dist/r0)) * prf/ps(i,j) 
+                        endif
+                     enddo
+                  enddo
+               enddo
+           endif
           if ( hydrostatic ) then
           call p_var(npz, is, ie, js, je, ptop, ptop_min, delp, delz, pt, ps,   &
                      pe, peln, pk, pkz, kappa, q, ng, ncnst, area, dry_mass, .false., .false., &
@@ -6734,26 +6734,26 @@ end subroutine terminator_tracers
                    .true., hydrostatic, nwat, domain, flagstruct%adiabatic)
 
 ! *** Add Initial perturbation ***
-	if (bubble_do) then
-	    r0 = 10.e3
-	    zc = 1.4e3         ! center of bubble  from surface
-	    icenter = (npx-1)/2 + 1
-	    jcenter = (npy-1)/2 + 1
-	    do k=1, npz
-	       zm = 0.5*(ze1(k)+ze1(k+1))
-	       ptmp = ( (zm-zc)/zc ) **2
-	       if ( ptmp < 1. ) then
-		  do j=js,je
-		     do i=is,ie
-		       dist = ptmp+((i-icenter)*dx_const/r0)**2+((j-jcenter)*dy_const/r0)**2
-		       if ( dist < 1. ) then
-			    pt(i,j,k) = pt(i,j,k) + pturb*(1.-sqrt(dist))
-		       endif
-		     enddo
-		  enddo
-	       endif
-	    enddo
-	 endif
+        if (bubble_do) then
+            r0 = 10.e3
+            zc = 1.4e3         ! center of bubble  from surface
+            icenter = (npx-1)/2 + 1
+            jcenter = (npy-1)/2 + 1
+            do k=1, npz
+               zm = 0.5*(ze1(k)+ze1(k+1))
+               ptmp = ( (zm-zc)/zc ) **2
+               if ( ptmp < 1. ) then
+                  do j=js,je
+                     do i=is,ie
+                        dist = ptmp+((i-icenter)*dx_const/r0)**2+((j-jcenter)*dy_const/r0)**2
+                         if ( dist < 1. ) then
+                              pt(i,j,k) = pt(i,j,k) + pturb*(1.-sqrt(dist))
+                         endif
+                     enddo
+                   enddo
+               endif
+             enddo
+        endif
 
         case ( 101 )
 
@@ -6904,6 +6904,7 @@ end subroutine terminator_tracers
         integer :: ierr, f_unit, unit, ios
 
 #include<file_version.h>
+        namelist /test_case_nml/test_case, bubble_do, alpha, nsolitons,soliton_Umax, soliton_size
 
         unit = stdlog()
 
@@ -6911,7 +6912,6 @@ end subroutine terminator_tracers
         alpha = 0.
         bubble_do = .false.
         test_case = 11   ! (USGS terrain)
-        namelist /test_case_nml/test_case, bubble_do, alpha, nsolitons, soliton_Umax, soliton_size
         
 #ifdef INTERNAL_FILE_NML
         ! Read Test_Case namelist


### PR DESCRIPTION
Fixes for GNU compilation issues: (NOAA-GFDL#32)
* Remove trailing whitespace and any tabs
* Add default values for nest_*offsets in fv_control
* fix GNU out-of-bound error in driver/fvGFS/atmosphere.F90
* Correct Z dimensions for driver/fvGFS/atmosphere.F90

All changes from @XiaqiongZhou-NOAA

Associated PRs:
https://github.com/ufs-community/ufs-weather-model/pull/151/files
https://github.com/NOAA-EMC/fv3atm/pull/131
https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere/pull/22

For regression testing information, see below https://github.com/ufs-community/ufs-weather-model/pull/151/files.