### PR TITLE
Changes for when INTERNAL_FILE_NML is not used

### DIFF
--- a/model/fv_control.F90
+++ b/model/fv_control.F90
@@ -993,7 +993,7 @@ module fv_control_mod
        ! Read Main namelist
        read (f_unit,fv_grid_nml,iostat=ios)
        ierr = check_nml_error(ios,'fv_grid_nml')
-       rewind (f_unit)
+       call close_file (f_unit)
 #endif
        call write_version_number ( 'FV_CONTROL_MOD', version )
        unit = stdlog()

--- a/tools/test_cases.F90
+++ b/tools/test_cases.F90
@@ -113,7 +113,7 @@
 
       use mpp_mod,           only: mpp_error, FATAL, mpp_root_pe, mpp_broadcast, mpp_sum
       use mpp_mod,           only: stdlog, input_nml_file
-      use fms_mod,           only: check_nml_error
+      use fms_mod,           only: check_nml_error, close_file, open_namelist_file
       use mpp_domains_mod,   only: mpp_update_domains, domain2d
       use mpp_parameter_mod, only: AGRID_PARAM=>AGRID,CGRID_NE_PARAM=>CGRID_NE, &
                                    SCALAR_PAIR


### PR DESCRIPTION
At the JCSDA we don't use the INTERNAL_FILE_NML compiler definition since we need to use different resolutions in the same executable. After the most recent merging from GFDL this capability stopped working. A couple of simple changes to make it work again.

In test_cases.f90 there are some missing includes.

In fv_control.f90 GNU compilers don't like trying to open an already open file.