### PR TITLE
Update dev/emc from gsd/develop 2020/06/30

### DIFF
--- a/tools/fv_diagnostics.F90
+++ b/tools/fv_diagnostics.F90
@@ -1549,7 +1549,7 @@ contains
                           isc, iec, jsc, jec, 0, npz, 1.)
           call prt_maxmin('Bottom DZ (m)', Atm(n)%delz(isc:iec,jsc:jec,npz),    &
                           isc, iec, jsc, jec, 0, 1, 1.)
-!         call prt_maxmin('Top DZ (m)', Atm(n)%delz(isc:iec,jsc:jec,1),    &
+!         call prt_maxmin('Top DZ (m)', Atm(n)%delz(is:ie,js:jec,1),    &
 !                         isc, iec, jsc, jec, 0, 1, 1.)
         endif
 
@@ -5572,7 +5572,7 @@ end subroutine eqv_pot
    real, intent(in):: grav, zvir, z_bot, z_top
    real, intent(in), dimension(is-ng:ie+ng,js-ng:je+ng,km):: pt
    real, intent(in), dimension(is:ie,js:je,km):: vort
-   real, intent(in):: delz(is-ng:ie+ng,js-ng:je+ng,km)
+   real, intent(in):: delz(is:ie,js:je,km)
    real, intent(in):: q(is-ng:ie+ng,js-ng:je+ng,km,*)
    real, intent(in):: phis(is-ng:ie+ng,js-ng:je+ng)
    real, intent(in):: peln(is:ie,km+1,js:je)
@@ -5630,7 +5630,7 @@ end subroutine eqv_pot
    real, intent(in):: grav, zvir, z_bot, z_top
    real, intent(in), dimension(is-ng:ie+ng,js-ng:je+ng,km):: pt, w
    real, intent(in), dimension(is:ie,js:je,km):: vort
-   real, intent(in):: delz(is-ng:ie+ng,js-ng:je+ng,km)
+   real, intent(in):: delz(is:ie,js:je,km)
    real, intent(in):: q(is-ng:ie+ng,js-ng:je+ng,km,*)
    real, intent(in):: phis(is-ng:ie+ng,js-ng:je+ng)
    real, intent(in):: peln(is:ie,km+1,js:je)

--- a/tools/fv_diagnostics.F90
+++ b/tools/fv_diagnostics.F90
@@ -1549,7 +1549,7 @@ contains
                           isc, iec, jsc, jec, 0, npz, 1.)
           call prt_maxmin('Bottom DZ (m)', Atm(n)%delz(isc:iec,jsc:jec,npz),    &
                           isc, iec, jsc, jec, 0, 1, 1.)
-!         call prt_maxmin('Top DZ (m)', Atm(n)%delz(is:ie,js:jec,1),    &
+!         call prt_maxmin('Top DZ (m)', Atm(n)%delz(isc:iec,jsc:jec,1),    &
 !                         isc, iec, jsc, jec, 0, 1, 1.)
         endif
 


### PR DESCRIPTION
Changes in this PR:
- contains a bugfix that corrects the dimensions of `delz` as in PR https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere/pull/27 (the latter can be closed after this PR has been merged)

Users at GSL have reported that after merging this bugfix, the model crashes they have seen after the dycore was updated went away.

Associated PRs:
https://github.com/NCAR/ccpp-physics/pull/465
https://github.com/NCAR/ccpp-framework/pull/307
https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere/pull/30
https://github.com/NOAA-EMC/fv3atm/pull/134
https://github.com/ufs-community/ufs-weather-model/pull/156

For regression testing information, see https://github.com/ufs-community/ufs-weather-model/pull/156.