### PR TITLE
Dev/jcsda

### DIFF
--- a/tools/external_ic.F90
+++ b/tools/external_ic.F90
@@ -201,6 +201,7 @@ module external_ic_mod
    character (len = 80) :: source   ! This tells what the input source was for the data
    character(len=27), parameter :: source_fv3gfs = 'FV3GFS GAUSSIAN NEMSIO FILE'
   public get_external_ic, get_cubed_sphere_terrain
+  public remap_scalar, remap_dwinds
 
 ! version number of this module
 ! Include variable "version" to be written to log file.

--- a/tools/external_ic.F90
+++ b/tools/external_ic.F90
@@ -998,8 +998,6 @@ contains
       jsd = Atm%bd%jsd
       jed = Atm%bd%jed
 
-      deg2rad = pi/180.
-
       npz = Atm%npz
       call get_number_tracers(MODEL_ATMOS, num_tracers=ntracers, num_prog=ntprog)
       if(is_master()) write(*,*) 'ntracers = ', ntracers, 'ntprog = ',ntprog
@@ -1562,8 +1560,6 @@ contains
       ied = Atm%bd%ied
       jsd = Atm%bd%jsd
       jed = Atm%bd%jed
-
-      deg2rad = pi/180.
 
       npz = Atm%npz
       call get_number_tracers(MODEL_ATMOS, num_tracers=ntracers, num_prog=ntprog)

--- a/tools/external_ic.F90
+++ b/tools/external_ic.F90
@@ -197,8 +197,8 @@ module external_ic_mod
 
    real, parameter:: zvir = rvgas/rdgas - 1.
    real(kind=R_GRID), parameter :: cnst_0p20=0.20d0
-   real :: deg2rad
-   character (len = 80) :: source   ! This tells what the input source was for the data
+   real, parameter :: deg2rad = pi/180.
+   character (len = 80), public :: source   ! This tells what the input source was for the data
    character(len=27), parameter :: source_fv3gfs = 'FV3GFS GAUSSIAN NEMSIO FILE'
   public get_external_ic, get_cubed_sphere_terrain
   public remap_scalar, remap_dwinds

--- a/tools/fv_grid_tools.F90
+++ b/tools/fv_grid_tools.F90
@@ -629,7 +629,7 @@ contains
 
     if (Atm%neststruct%nested .or. ANY(Atm%neststruct%child_grids)) then
         grid_global => Atm%grid_global
-    else if( trim(grid_file) .NE. 'INPUT/grid_spec.nc') then
+    else if( trim(grid_file) .EQ. 'Inline') then
        allocate(grid_global(1-ng:npx  +ng,1-ng:npy  +ng,ndims,1:nregions))
     endif
     
@@ -683,7 +683,7 @@ contains
              ! still need to set up 
              call setup_aligned_nest(Atm)
           else
-           if(trim(grid_file) == 'INPUT/grid_spec.nc') then  
+           if(trim(grid_file) .NE. 'Inline') then  
              call read_grid(Atm, grid_file, ndims, nregions, ng)
            else
             if (Atm%flagstruct%grid_type>=0) call gnomonic_grids(Atm%flagstruct%grid_type, npx-1, xs, ys)
@@ -1181,7 +1181,7 @@ contains
 
     if (Atm%neststruct%nested .or. ANY(Atm%neststruct%child_grids)) then
     nullify(grid_global)
-    else if( trim(grid_file) .NE. 'INPUT/grid_spec.nc') then
+    else if( trim(grid_file) .EQ. 'Inline') then
        deallocate(grid_global)
     endif
 


### PR DESCRIPTION
Two pieces of development that are needed on the JCSDA side.

1. To make the remapping methods used in the cold start reader public and usable from outside. This is so that we can read cold starts in the fv3-jedi interface and access remapping where we need it.

2. To address the issue described in #32.

closes: #32 