### PR TITLE
Removed use of mpp_node for use with FMS 2020.04

### DIFF
--- a/tools/fv_mp_mod.F90
+++ b/tools/fv_mp_mod.F90
@@ -72,7 +72,7 @@
 ! !USES:
       use fms_mod,         only : fms_init, fms_end
       use mpp_mod,         only : FATAL, MPP_DEBUG, NOTE, MPP_CLOCK_SYNC,MPP_CLOCK_DETAILED, WARNING
-      use mpp_mod,         only : mpp_pe, mpp_npes, mpp_node, mpp_root_pe, mpp_error, mpp_set_warn_level
+      use mpp_mod,         only : mpp_pe, mpp_npes, mpp_root_pe, mpp_error, mpp_set_warn_level
       use mpp_mod,         only : mpp_declare_pelist, mpp_set_current_pelist, mpp_sync
       use mpp_mod,         only : mpp_clock_begin, mpp_clock_end, mpp_clock_id
       use mpp_mod,         only : mpp_chksum, stdout, stderr, mpp_broadcast


### PR DESCRIPTION
In FMS 2020.04, ```mpp_node``` is no longer supported.  ```mpp_node``` was not used in the GFDL_atmos_cubed_sphere, but it was in a use statement in fv_mp_mod.  This PR removes that use statement.