### PR TITLE
dev/emc: initialize cld_amt to zero for regional runs (cherry-picked from ufs-release/public-v2)

### DIFF
--- a/model/fv_regional_bc.F90
+++ b/model/fv_regional_bc.F90
@@ -3701,7 +3701,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 ! If the source is from old GFS or operational GSM then the tracers will be fixed in the boundaries
 ! and may not provide a very good result
 ! 
-!  if (cld_amt .gt. 0) BC_side%q_BC(:,:,:,cld_amt) = 0.
+  if (cld_amt .gt. 0) BC_side%q_BC(:,:,:,cld_amt) = 0.
   if (trim(data_source) /= 'FV3GFS GAUSSIAN NEMSIO FILE') then
    if ( Atm%flagstruct%nwat .eq. 6 ) then
       do k=1,npz


### PR DESCRIPTION
This PR is a cherry-pick of commit 48ea7195caf573eb4ad98662dbaf29ebf728e361 that went into the ufs-release/public-v2 branch of the authoritative (NOAA-GFDL) repository. See https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/pull/62 for more information.
