### PR TITLE
feature/cmake_in_dycore: changes to compile FV3 dycore without CCPP (or any physics) for JEDI, cannot use driver code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ else()
   set(FMS_COMPONENTS "R8")
   set(kind "r8")
 endif()
-find_package(FMS REQUIRED COMPONENTS ${FMS_COMPONENTS})
+find_package(FMS REQUIRED COMPONENTS ${FMS_COMPONENTS} PATHS /Users/dom.heinzeller/scratch/fms/fms-2020.04.03-private-compiler-defs/install)
 
 add_library(fms ALIAS FMS::fms_${kind})
 #if(32BIT)
@@ -92,7 +92,6 @@ list(APPEND tools_srcs
   tools/fv_mp_mod.F90
   tools/fv_nudge.F90
   tools/fv_treat_da_inc.F90
-  tools/fv_iau_mod.F90
   tools/fv_restart.F90
   tools/fv_surf_map.F90
   tools/fv_timing.F90
@@ -100,6 +99,9 @@ list(APPEND tools_srcs
   tools/sim_nc_mod.F90
   tools/sorted_index.F90
   tools/test_cases.F90)
+
+list(APPEND tools_srcs_extra
+  tools/fv_iau_mod.F90)
 
 list(APPEND driver_srcs
   driver/fvGFS/DYCORE_typedefs.F90
@@ -132,7 +134,8 @@ endif()
 
 if(use_WRTCOMP)
   list(APPEND fv3_defs use_WRTCOMP)
-  list(APPEND fv3_srcs ${driver_srcs})
+  list(APPEND fv3_srcs ${tools_srcs_extra}
+                       ${driver_srcs})
 endif()
 
 if(MULTI_GASES)

--- a/model/fv_sg.F90
+++ b/model/fv_sg.F90
@@ -1,3 +1,4 @@
+#define GFS_PHYS
 !***********************************************************************
 !*                   GNU Lesser General Public License
 !*

--- a/tools/fv_diag_column.F90
+++ b/tools/fv_diag_column.F90
@@ -84,10 +84,9 @@ contains
 #else
     inquire (file=trim(Atm%nml_filename), exist=exists)
     if (.not. exists) then
-      write(errmsg,*) 'fv_diag_column_nml: namelist file ',trim(Atm%nml_filename),' does not exist'
-      call mpp_error(FATAL, errmsg)
+      call mpp_error(FATAL, 'fv_diag_column_nml: namelist file ' // trim(Atm%nml_filename) // ' does not exist')
     else
-      open (unit=nlunit, file=Atm%nml_filename, READONLY, status='OLD', iostat=ios)
+      open (unit=nlunit, file=Atm%nml_filename, action='READ', status='OLD', iostat=ios)
     endif
     rewind(nlunit)
     read (nlunit, nml=fv_diag_column_nml, iostat=ios)

--- a/tools/fv_diagnostics.F90
+++ b/tools/fv_diagnostics.F90
@@ -1,3 +1,4 @@
+#define GFS_PHYS
 !***********************************************************************
 !*                   GNU Lesser General Public License
 !*
@@ -444,7 +445,7 @@ contains
       write(errmsg,*) 'fv_diag_plevs_nml: namelist file ',trim(Atm(n)%nml_filename),' does not exist'
       call mpp_error(FATAL, errmsg)
     else
-      open (unit=nlunit, file=Atm(n)%nml_filename, READONLY, status='OLD', iostat=ios)
+      open (unit=nlunit, file=Atm(n)%nml_filename, action='READ', status='OLD', iostat=ios)
     endif
     rewind(nlunit)
     read (nlunit, nml=fv_diag_plevs_nml, iostat=ios)

--- a/tools/test_cases.F90
+++ b/tools/test_cases.F90
@@ -1,3 +1,5 @@
+#define GFS_PHYS
+
 !***********************************************************************
 !*                   GNU Lesser General Public License
 !*


### PR DESCRIPTION
@aerorahul please check if this works for you / JEDI / UFS

Need to compile without `GFS_PHYS` in general. Requires FMS update to make compiler definitions and flags private (see https://github.com/NOAA-GFDL/FMS/issues/781).

Note that in a few places, `#define GFS_PHYS` had to be added to opt for the GFS implementation that doesn't require GFDL cloud microphysics code to be present.

Will abort if `GFS_PHYS` is off and `do_sat_adj` is true, since the saturation adjustment requires running physics.