### PR TITLE
Update external_ic.F90 and fv_nudge.F90 to use allocatable arrays

### DIFF
--- a/tools/external_ic.F90
+++ b/tools/external_ic.F90
@@ -4173,16 +4173,17 @@ contains
       integer i, j
       class(*) a(im,jm)
 
-      real(r4_kind) qmin(jm), qmax(jm)
-      real(r4_kind)  pmax, pmin
+      real(r4_kind), dimension(:), allocatable :: qmin, qmax
+      real(r4_kind) pmax, pmin
       class(*)  fac                     ! multiplication factor
-      real(r8_kind) qmin8(jm), qmax8(jm)
-      real(r8_kind)  pmax8, pmin8
+      real(r8_kind), dimension(:), allocatable :: qmin8, qmax8
+      real(r8_kind) pmax8, pmin8
 
       select type (fac)
       type is (real(kind=r4_kind))
          select type (a)
          type is (real(kind=r4_kind))
+         allocate(qmax(jm), qmin(jm))
          do j=1,jm
             pmax = a(1,j)
             pmin = a(1,j)
@@ -4202,6 +4203,7 @@ contains
             pmax = max(pmax, qmax(j))
             pmin = min(pmin, qmin(j))
          enddo
+         deallocate(qmax, qmin)
 
          write(*,*) qname, ' max = ', pmax*fac, ' min = ', pmin*fac
          class default
@@ -4211,6 +4213,7 @@ contains
       type is (real(kind=r8_kind))
          select type (a)
          type is (real(kind=r8_kind))
+         allocate(qmax8(jm), qmin8(jm))
          do j=1,jm
             pmax8 = a(1,j)
             pmin8 = a(1,j)
@@ -4230,6 +4233,7 @@ contains
             pmax8 = max(pmax8, qmax8(j))
             pmin8 = min(pmin8, qmin8(j))
          enddo
+         deallocate(qmax8, qmin8)
 
          write(*,*) qname, ' max = ', pmax8*fac, ' min = ', pmin8*fac
          class default

--- a/tools/fv_diagnostics.F90
+++ b/tools/fv_diagnostics.F90
@@ -118,7 +118,8 @@ module fv_diagnostics_mod
  use time_manager_mod,   only: time_type, get_date, get_time
  use mpp_domains_mod,    only: domain2d, mpp_update_domains, DGRID_NE, NORTH, EAST
  use diag_manager_mod,   only: diag_axis_init, register_diag_field, &
-                               register_static_field, send_data, diag_grid_init
+                               register_static_field, send_data, diag_grid_init, &
+                               diag_field_add_attribute
  use fv_arrays_mod,      only: fv_atmos_type, fv_grid_type, fv_diag_type, fv_grid_bounds_type, &
                                R_GRID
  use fv_mapz_mod,        only: E_Flux, moist_cv, moist_cp, mappm
@@ -534,6 +535,9 @@ contains
                                          'latitude', 'degrees_N' )
        id_area = register_static_field ( trim(field), 'area', axes(1:2),  &
                                          'cell area', 'm**2' )
+       if (id_area > 0) then
+         call diag_field_add_attribute (id_area, 'cell_methods', 'area: sum')
+       endif
        id_dx = register_static_field( trim(field), 'dx', (/id_xt,id_y/), &
             'dx', 'm')
        id_dy = register_static_field( trim(field), 'dy', (/id_x,id_yt/), &

--- a/tools/fv_nudge.F90
+++ b/tools/fv_nudge.F90
@@ -3545,16 +3545,17 @@ module fv_nwp_nudge_mod
       class(*) a(imax,jmax)
       class(*) fac                     ! multiplication factor
 
-      real(r4_kind) qmin(jmax), qmax(jmax)
+      real(r4_kind), dimension(:), allocatable :: qmin, qmax
       real(r4_kind) pmax, pmin
 
-      real(r8_kind) qmin8(jmax), qmax8(jmax)
+      real(r8_kind), dimension(:), allocatable :: qmin8, qmax8
       real(r8_kind) pmax8, pmin8
 
       select type (fac)
       type is (real(kind=r4_kind))
          select type (a)
          type is (real(kind=r4_kind))
+         allocate(qmax(jmax), qmin(jmax))
          do j=1,jmax
             pmax = a(1,j)
             pmin = a(1,j)
@@ -3574,6 +3575,7 @@ module fv_nwp_nudge_mod
             pmax = max(pmax, qmax(j))
             pmin = min(pmin, qmin(j))
          enddo
+         deallocate(qmax, qmin)
 
          write(*,*) qname, ' max = ', pmax*fac, ' min = ', pmin*fac
          class default
@@ -3583,6 +3585,7 @@ module fv_nwp_nudge_mod
       type is (real(kind=r8_kind))
          select type (a)
          type is (real(kind=r8_kind))
+         allocate(qmax8(jmax), qmin8(jmax))
          do j=1,jmax
             pmax8 = a(1,j)
             pmin8 = a(1,j)
@@ -3602,6 +3605,7 @@ module fv_nwp_nudge_mod
             pmax8 = max(pmax8, qmax8(j))
             pmin8 = min(pmin8, qmin8(j))
          enddo
+         deallocate(qmax8, qmin8)
 
          write(*,*) qname, ' max = ', pmax8*fac, ' min = ', pmin8*fac
          class default


### PR DESCRIPTION
The following two files are revised to use allocatable arrays:
tools/external_ic.F90
tools/fv_nudge.F90

Regression tests of ufs-weather-model can be run successfully with modified code and mixed_mode FMS.

fixes: #64 