### PR TITLE
AQM.v7 EE2 compliance: -ftrapuv and -check all in DEBUG build options

### DIFF
--- a/cmake/compiler_flags_Intel_Fortran.cmake
+++ b/cmake/compiler_flags_Intel_Fortran.cmake
@@ -10,7 +10,7 @@ set(CMAKE_Fortran_FLAGS_REPRO "-O2 -debug minimal -fp-model consistent -qoverrid
 
 set(CMAKE_Fortran_FLAGS_RELEASE "-O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3")
 
-set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -check -check noarg_temp_created -check nopointer -warn -warn noerrors -fp-stack-check -fstack-protector-all -fpe0 -debug -ftrapuv")
+set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -check all -warn -warn noerrors -fp-stack-check -fstack-protector-all -fpe0 -debug -ftrapuv")
 
 set(CMAKE_Fortran_LINK_FLAGS "")
 

--- a/cmake/compiler_flags_Intel_Fortran.cmake
+++ b/cmake/compiler_flags_Intel_Fortran.cmake
@@ -10,7 +10,7 @@ set(CMAKE_Fortran_FLAGS_REPRO "-O2 -debug minimal -fp-model consistent -qoverrid
 
 set(CMAKE_Fortran_FLAGS_RELEASE "-O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3")
 
-set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -check all -warn -warn noerrors -fp-stack-check -fstack-protector-all -fpe0 -debug -ftrapuv")
+set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -check all -check noarg_temp_created -warn -warn noerrors -fp-stack-check -fstack-protector-all -fpe0 -debug -ftrapuv")
 
 set(CMAKE_Fortran_LINK_FLAGS "")
 

--- a/tools/external_ic.F90
+++ b/tools/external_ic.F90
@@ -3096,7 +3096,6 @@ contains
 
 ! map tracers
       do iq=1,ncnst
-        if (floor(qa(is,j,1,iq)) == -1000) cycle !skip missing scalars [floor(-999.99) is -1000]
          do k=1,km
             do i=is,ie
                qp(i,k) = qa(i,j,k,iq)


### PR DESCRIPTION
This PR replaces all `-check` build flags with `-check all` for EE2 compliance for AQM v7