### PR TITLE
[production/AQM.v7] Address warnings after removing -nowarn from Intel CMake

### DIFF
--- a/cmake/compiler_flags_Intel_Fortran.cmake
+++ b/cmake/compiler_flags_Intel_Fortran.cmake
@@ -4,7 +4,7 @@ set(R8_flags "-real-size 64") # Fortran flags for 64BIT precision
 set(R8_flags "${R8_flags} -no-prec-div -no-prec-sqrt")
 
 # Intel Fortran
-set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g -traceback -fpp -fno-alias -auto -safe-cray-ptr -ftz -assume byterecl -nowarn -sox -align array64byte -qno-opt-dynamic-align ${${kind}_flags}")
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g -traceback -fpp -fno-alias -auto -safe-cray-ptr -ftz -assume byterecl -sox -align array64byte -qno-opt-dynamic-align ${${kind}_flags}")
 
 set(CMAKE_Fortran_FLAGS_REPRO "-O2 -debug minimal -fp-model consistent -qoverride-limits")
 

--- a/model/fv_regional_bc.F90
+++ b/model/fv_regional_bc.F90
@@ -4117,7 +4117,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
                                                                ,pt
 !
       real,dimension(bd%isd:,bd%jsd:,1:),intent(out) :: w
-      real,dimension(bd%is:,bd%js:,1:),intent(out) :: delz
+      real,dimension(bd%is:,bd%js:,1:),intent(inout) :: delz
 #ifdef USE_COND
       real,dimension(bd%isd:,bd%jsd:,1:),intent(out) :: q_con
 #endif
@@ -4424,7 +4424,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 !---------------------
 !
       integer :: i1,i2,j1,j2                                             !<-- Horizontal limits of region updated.
-      integer :: i_bc,j_bc                                               !<-- Innermost bndry index (anchor point for blending)
+      integer(kind=8) :: i_bc,j_bc                                               !<-- Innermost bndry index (anchor point for blending)
       integer :: i1_blend,i2_blend,j1_blend,j2_blend                     !<-- Limits of updated blending region.
       integer :: lbnd1,ubnd1,lbnd2,ubnd2                                 !<-- Horizontal limits of BC update arrays.
       integer :: iq                                                      !<-- Tracer index
@@ -4838,8 +4838,9 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 !
       integer,intent(in) :: lbnd1,ubnd1,lbnd2,ubnd2                      !<-- Index limits of the BC arrays.
 !
+      integer(kind=8),intent(in) :: i_bc,j_bc
       integer,intent(in) :: i1,i2,j1,j2                               &  !<-- Index limits of the updated boundary region.
-                           ,i_bc,j_bc                                 &  !<-- Innermost bndry indices (anchor pts for blending)
+!                           ,i_bc,j_bc                                 &  !<-- Innermost bndry indices (anchor pts for blending)
                            ,i1_blend,i2_blend,j1_blend,j2_blend       &  !<-- Index limits of the updated blending region.
                            ,nside
 !

--- a/tools/fv_nudge.F90
+++ b/tools/fv_nudge.F90
@@ -2427,13 +2427,13 @@ module fv_nwp_nudge_mod
       enddo
 
       call compute_slp(is, ie, js, je, tm, ps, phis(is:ie,js:je), slp)
-
+123   continue
     if ( r_vor < 30.E3 .or. p_env<900.E2 ) then
 
 ! Compute r_vor & p_env
          r_vor = r_min + (slp_env-slp_o)/25.E2*r_inc
 
-123   continue
+!123   continue
       p_count = 0.
         p_sum = 0.
         a_sum = 0.

--- a/tools/module_diag_hailcast.F90
+++ b/tools/module_diag_hailcast.F90
@@ -58,7 +58,7 @@ CONTAINS
         INTEGER,           INTENT(IN)    :: isco,ieco,jsco,jeco
         INTEGER,           INTENT(INOUT) :: nlevs
         real,              INTENT(IN)    :: missing_value
-        INTEGER,           INTENT(OUT)   :: istatus
+        INTEGER,           INTENT(INOUT)   :: istatus
 
         INTEGER :: i, j
 

--- a/tools/test_cases.F90
+++ b/tools/test_cases.F90
@@ -5475,7 +5475,7 @@ end subroutine terminator_tracers
  real, intent(inout), dimension(km+1):: ak, bk
  real, intent(inout), dimension(is:ie,js:je,km):: pt
  real, intent(inout), dimension(is:,js:,1:) :: delz
- real, intent(out), dimension(is:ie,js:je,km+1):: pk
+ real, intent(inout), dimension(is:ie,js:je,km+1):: pk
 ! pt is FV's cp*thelta_v
  real, intent(inout), dimension(is-1:ie+1,km+1,js-1:je+1):: pe
 ! Local
@@ -5664,7 +5664,7 @@ end subroutine terminator_tracers
  integer, intent(in):: km
  real, intent(in):: ps     ! surface pressure (Pa)
  real, intent(in), dimension(km):: pk1
- real, intent(out), dimension(km):: tp, qp
+ real, intent(inout), dimension(km):: tp, qp
 ! Local:
  integer, parameter:: ns = 401
  integer, parameter:: nx = 3


### PR DESCRIPTION
**Description**
NCO Wishes to remove all -nowarn from non-debug builds for production/AQM.v7

This PR addresses the warnings from removing -nowarn

**How Has This Been Tested?**
Builds now are warning free from non-debug using the AQM.v7 production branch
Adjustments were testing to ensure results do not change.
