### PR TITLE
[production/RRFS.v1] Fix 'check all' using 0-sized allocations

### DIFF
--- a/driver/fvGFS/atmosphere.F90
+++ b/driver/fvGFS/atmosphere.F90
@@ -2113,7 +2113,7 @@ contains
          IPD_Data(nb)%Statein%tgrs(ix,k) = _DBL_(_RL_(Atm(mygrid)%pt(i,j,k1)))
          IPD_Data(nb)%Statein%ugrs(ix,k) = _DBL_(_RL_(Atm(mygrid)%ua(i,j,k1)))
          IPD_Data(nb)%Statein%vgrs(ix,k) = _DBL_(_RL_(Atm(mygrid)%va(i,j,k1)))
-         if(associated(IPD_Data(nb)%Statein%wgrs) .and. .not. Atm(mygrid)%flagstruct%hydrostatic) then
+         if(size(IPD_Data(nb)%Statein%wgrs) > 0 .and. .not. Atm(mygrid)%flagstruct%hydrostatic) then
            IPD_Data(nb)%Statein%wgrs(ix,k) = _DBL_(_RL_(Atm(mygrid)%w(i,j,k1)))
          endif
          IPD_Data(nb)%Statein%vvl(ix,k)  = _DBL_(_RL_(Atm(mygrid)%omga(i,j,k1)))


### PR DESCRIPTION
**Description**

This small change is part of a larger project to pass NCO's requirements of compiling the UFS with the `-check all` compiler option. Previously conditionally-allocated arrays in fv3atm (particularly GFS_typedefs and CCPP_typedefs) need to always be allocated (at least to zero size) in order to NOT run into runtime errors with the `-check all` option (used in DEBUG mode). The only change needed in this repo is related to the vertical velocity (wgrs) variable that was added to physics a while back for the lightning algorithm.

https://github.com/ufs-community/ufs-weather-model/issues/2023


**How Has This Been Tested?**

This was tested using UFS regression tests on Hera with the `-check all` compiler option added for Intel.

**Checklist:**

Please check all whether they apply or not
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
