### PR TITLE
Bug fix to the HAILCAST diagnostic code

### DIFF
--- a/tools/module_diag_hailcast.F90
+++ b/tools/module_diag_hailcast.F90
@@ -1092,8 +1092,7 @@ CONTAINS
       IF (D.GT.0.254) D = 0.  !just consider missing for now if > 10 in
 
       !assign hail size in mm for output
-      !dhails(i) = D * 1000
-      dhails(i) = D
+      dhails(i) = D * 1000
 
     ENDDO  !end embryo size loop
 


### PR DESCRIPTION
**Description**

This PR fixes a units bug in the HAILCAST diagnostic code.

An identical PR was merged into the **dev/emc** branch of NOAA-GFDL/GFDL_atmos_cubed_sphere; see https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/pull/320 .  This PR accomplishes the same fix to the **production/RRFS.v1** branch of the NOAA-EMC fork.

**How Has This Been Tested?**

Testing details are available via the previous PR at the link above.

**Checklist:**

Please check all whether they apply or not
- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ x] Any dependent changes have been merged and published in downstream modules
