### PR TITLE
[production/RRFS.v1] fix hailcast crash under DEBUG by initializing variables approriately

### DIFF
--- a/tools/module_diag_hailcast.F90
+++ b/tools/module_diag_hailcast.F90
@@ -920,6 +920,16 @@ CONTAINS
       IF (wdur .LT. RTIME) RTIME = wdur
 
       TFZL = tk_embryo
+
+      WFZLP = 0.0
+      ZFZL = 0.0
+      RFZL = 0.0
+      VUFZL = 0.0
+      DENSAFZL = 0.0
+      VUMAX = 0.0
+      RI = 0.0
+      RW =0.0
+
       CALL INTERPP(PA, WFZLP, TCA, tk_embryo, IFOUT, nz)
       CALL INTERP(h1d, ZFZL, WFZLP, IFOUT, PA, nz)
       CALL INTERP(RA,  RFZL, WFZLP, IFOUT, PA, nz)


### PR DESCRIPTION
**Description**

This PR is to fix RRFS crash related to hailcast under DEBUG compilation. When the hail embryo temperature falls outside the range of the vertical temperature column, which happens occasionally, NaNs are generated. The fix is to initialize several variables before the interpolation. Thanks @dkokron for catching this!

**How Has This Been Tested?**

This PR has been tested for RRFS and no changes are expected on the forecast when compiling without DEBUG.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
