### PR TITLE
[production/GEFS.v12] Change dz_min from 2 to 12

### DIFF
--- a/model/nh_utils.F90
+++ b/model/nh_utils.F90
@@ -66,7 +66,7 @@ module nh_utils_mod
    public sim3p0_solver, rim_2d
    public Riem_Solver_c
 
-   real, parameter:: dz_min = 2.
+   real, parameter:: dz_min = 12.
    real, parameter:: r3 = 1./3.
 
 CONTAINS 


### PR DESCRIPTION
**Description**

This PR updates `dz_min` from `2` to `12` for GEFSv12. This change improves numerical stability of the model. 5 model crashes occurred in GEFSv12 ops during June and July. Increasing the `dz_min` to `12` fixed these model crashes. 

Fixes #93 

**How Has This Been Tested?**

This change has been tested in the GEFSv12 package on WCOSS2 for the following cases:

1. 20260706 00Z p18
2. 20260704 00Z p08
3. 20260703 06Z p26
4. 20260630 00Z p08
5. 20260630 18Z p11


**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
